### PR TITLE
Add L2 VLS, with support for 1 segment

### DIFF
--- a/src/main/scala/uncore.scala
+++ b/src/main/scala/uncore.scala
@@ -3,6 +3,7 @@
 package uncore
 import Chisel._
 import cde.{Parameters, Field}
+import junctions.SmiIO
 
 case object NReleaseTransactors extends Field[Int]
 case object NProbeTransactors extends Field[Int]
@@ -103,9 +104,19 @@ abstract class ManagerCoherenceAgent(implicit p: Parameters) extends CoherenceAg
   def incoherent = io.incoherent
 }
 
+trait HasLocalConfIO {
+  val lconf = new SmiIO(64,12).flip // TODO: configure widths properly
+}
+
+trait HasGlobalConfIO {
+  val gconf = new SmiIO(64,12).flip // TODO: configure widths properly
+}
+
 class HierarchicalTLIO(implicit p: Parameters) extends CoherenceAgentBundle()(p)
   with HasInnerTLIO
   with HasCachedOuterTLIO
+  with HasGlobalConfIO
+  with HasLocalConfIO
 
 abstract class HierarchicalCoherenceAgent(implicit p: Parameters) extends CoherenceAgent()(p) {
   val io = new HierarchicalTLIO

--- a/src/main/scala/vls.scala
+++ b/src/main/scala/vls.scala
@@ -1,0 +1,71 @@
+package uncore
+
+import Chisel._
+import junctions._
+import cde.{Parameters, Field}
+
+case object UseVLS extends Field[Boolean]
+case object NVLSCacheSegments extends Field[Int]
+case object SplitMetadata extends Field[Boolean]
+
+trait HasVLSParameters {
+  implicit val p: Parameters
+  val nVLSCacheSegments = p(NVLSCacheSegments)
+  val pAddrBits = p(PAddrBits)
+}
+
+class VLSAllocation(implicit val p: Parameters) extends Bundle
+  with HasVLSParameters {
+    val pbase = Bits(INPUT, width = pAddrBits)
+    val size = Bits(INPUT, width = pAddrBits)
+}
+
+class VLSManager(implicit val p: Parameters) extends Module
+  with HasVLSParameters 
+  with HasCacheParameters {
+  val io = new Bundle {
+    val conf = new SmiIO(pAddrBits,17).flip // 1M addr map space
+    val vls = Vec.fill(nVLSCacheSegments)(new VLSAllocation().flip)
+  }
+  def mask(in: Int) = Bits((1 << in) - 1)
+  def genSize(in: Bits) = {
+    val rndUp = in + mask(untagBits)
+    rndUp & (mask(wayBits) << untagBits)
+  }
+  val addrWidth = 20
+  val vlsBases = List.fill(nVLSCacheSegments)(Reg(init = Bits(0, width = pAddrBits)))
+  val vlsSizes = List.fill(nVLSCacheSegments)(Reg(init = Bits(0, width = pAddrBits)))
+  val ren = io.conf.req.fire() && !io.conf.req.bits.rw
+  val wen = io.conf.req.fire() && io.conf.req.bits.rw
+  val addr = io.conf.req.bits.addr
+  val nSegs = Bits(nVLSCacheSegments)
+  val read_mapping = collection.mutable.LinkedHashMap[Int,Bits](0 -> nSegs)
+  val wdata = io.conf.req.bits.data
+  val base_mask = mask(tagBits - wayBits) << (untagBits + wayBits)
+  val wdata_base = wdata & base_mask
+  val wdata_size = genSize(wdata)
+  (0 until nVLSCacheSegments).foreach(i => {
+    read_mapping += 2*(i+1) -> vlsBases(i)
+    read_mapping += 2*(i+1)+1 -> vlsSizes(i)
+    io.vls(i).pbase := vlsBases(i)
+    io.vls(i).size := vlsSizes(i)
+    when (wen && (addr === Bits(2*(i+1)))) { vlsBases(i) := wdata_base }
+    when (wen && (addr === Bits(2*(i+1)+1))) { vlsSizes(i) := wdata_size }
+  })
+  val decoded_addr = read_mapping map { case (k, v) => k -> (addr === Bits(k)) }
+  val rdata = Mux1H(for ((k, v) <- read_mapping) yield decoded_addr(k) -> v)
+  val rdata_reg = Reg(init = Bits(0))
+  val resp_valid = Reg(init = Bool(false))
+  io.conf.resp.valid := resp_valid
+  io.conf.resp.bits := rdata_reg
+  io.conf.req.ready := !resp_valid
+  when (io.conf.resp.fire()) {
+    resp_valid := Bool(false)
+  }
+  when (io.conf.req.fire())  {
+    resp_valid := Bool(true)
+    rdata_reg := rdata
+  }
+
+
+}


### PR DESCRIPTION
Not necessarily trying to merge this as is, but I'd like to see how I could move to upstreaming VLS. There's also a corresponding branch for rocket-chip with the appropriate parameters in configs and the AXI hookups for VLS configuration, but I'm certainly happy to clean things up in my uncore changes first. Otherwise, I could open a pull request for rocket-chip too.