### PR TITLE
Add an assertion in the NastiIOTileLink converter

### DIFF
--- a/src/main/scala/converters.scala
+++ b/src/main/scala/converters.scala
@@ -500,6 +500,7 @@ class NastiIOTileLinkIOConverter(implicit p: Parameters) extends TLModule()(p)
     manager_xact_id = UInt(0),
     addr_beat = Mux(roq.io.deq.data.subblock, roq.io.deq.data.addr_beat, tl_cnt_in),
     data = r_aligned_data)
+  assert(!gnt_arb.io.in(0).valid || roq.io.deq.matches, "NASTI tag error")
 
   gnt_arb.io.in(1).valid := io.nasti.b.valid
   io.nasti.b.ready := gnt_arb.io.in(1).ready


### PR DESCRIPTION
This uses an reorder queue but doesn't check to ensure that the data it fetches
from the queue is actually in the queue before using it.  It seems that during
correct operation this never breaks, but I'm trying to get the backup memory
port working again and this assertion fails with it enabled (without the
assertion the core just gets a bogus data beat dies).