### PR TITLE
Make sure there's enough xact id bits

### DIFF
--- a/src/main/scala/rtc.scala
+++ b/src/main/scala/rtc.scala
@@ -51,6 +51,7 @@ class RTC(csr_MTIME: Int)(implicit p: Parameters) extends HtifModule
     id = coreId,
     addr = addrTable(coreId),
     size = UInt(log2Up(csrDataBytes)))
+  require(p(MIFMasterTagBits) >= log2Up(nCores))
 
   io.w.valid := sending_data
   io.w.bits := NastiWriteDataChannel(data = rtc)


### PR DESCRIPTION
We were bitten by a NASTI (heh heh) bug resulting from violation of this inequality, so add it as a check for all future builds.  This depends on ucb-bar/junctions#12 in junctions, "Define MIFMasterTagBits as # bits a master can *use* in tag", which defines the `MIFMasterTagBits` case object.