### PR TITLE
Chisel 3 support

### DIFF
--- a/src/main/scala/cache.scala
+++ b/src/main/scala/cache.scala
@@ -953,7 +953,7 @@ class L2AcquireTracker(trackerId: Int)(implicit p: Parameters) extends L2XactTra
   io.data.write.bits.way_en := xact_way_en
   io.data.write.bits.addr_idx := xact_addr_idx
   io.data.write.bits.addr_beat := curr_write_beat
-  io.data.write.bits.wmask := SInt(-1) // Always writes a full beat
+  io.data.write.bits.wmask := ~UInt(0, io.data.write.bits.wmask.getWidth)
   io.data.write.bits.data := data_buffer(curr_write_beat)
 
   // soon as the data is released, granted, put, or read from the cache

--- a/src/main/scala/htif.scala
+++ b/src/main/scala/htif.scala
@@ -38,6 +38,8 @@ class HostIO(w: Int) extends Bundle {
   val in = Decoupled(Bits(width = w)).flip
   val out = Decoupled(Bits(width = w))
   val debug_stats_csr = Bool(OUTPUT)
+
+  override def cloneType = new HostIO(w).asInstanceOf[this.type]
 }
 
 class HtifIO(implicit p: Parameters) extends HtifBundle()(p) {
@@ -234,6 +236,8 @@ class NastiIOHostIOConverter(htifW: Int)(implicit val p: Parameters)
     val host = new HostIO(htifW).flip
     val reset = Bool(OUTPUT)
   }
+
+  def cloneType = new NastiIOHostIOConverter(htifW).asInstanceOf[this.type]
 
   val raddr = io.nasti.ar.bits.addr(6, 2)
   val waddr = io.nasti.aw.bits.addr(6, 2)


### PR DESCRIPTION
This adds some small changes that Chisel 3 needs.  They are all backwards compatible with Chisel 2 and still simulate correctly with Chisel 2.