### PR TITLE
ensure that output is not valid if we are unable to alloc 

### DIFF
--- a/src/main/scala/uncore.scala
+++ b/src/main/scala/uncore.scala
@@ -87,7 +87,7 @@ trait HasCoherenceAgentWiringHelpers {
     val match_ok = matchOverride.getOrElse(Bool(true))
     in.ready := Mux(no_matches, ready_bits.orR, (match_bits & ready_bits).orR) && alloc_ok && match_ok
     outs.zip(allocs).zipWithIndex.foreach { case((out, a), i) =>
-      out.valid := in.valid && match_ok
+      out.valid := in.valid && match_ok && alloc_ok
       out.bits := in.bits
       dataOverrides foreach { d => out.bits.data := d(i) }
       a := alloc_bits(i) & no_matches & alloc_ok


### PR DESCRIPTION
and therefore deny incoming transaction

This fixed a bug I was encountering in the L2 where an inner acquire was being seen twice by the L2 because there was an acquire/release conflict but only the bank saw this while the tshrfile was still accepting the transaction.