### PR TITLE
[debug] Remove erroneous buffer on SB read data

### DIFF
--- a/src/main/scala/debug.scala
+++ b/src/main/scala/debug.scala
@@ -454,7 +454,7 @@ class DebugModule ()(implicit val p:cde.Parameters)
   val dbRamRdEn   = Wire(Bool())
 
   val sbRamAddr   = Wire(UInt(width=sbRamAddrWidth))
-  val sbRamRdData = Reg (UInt(width=sbRamDataWidth))
+  val sbRamRdData = Wire (UInt(width=sbRamDataWidth))
   val sbRamWrData = Wire(UInt(width=sbRamDataWidth))
   val sbRamWrEn   = Wire(Bool())
   val sbRamRdEn   = Wire(Bool())


### PR DESCRIPTION
The RAM data was being buffered for the System Bus read, which was causing the incorrect data to be returned if there was any sort of buffering.

[Fun fact... we are blinking LEDs through gdb after this fix...]